### PR TITLE
Subset fingerprints by important ligand-binding residues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,9 +90,11 @@ target/
 !/data/processed
 !/data/external
 /data/external/structures/*_KLIFS_HUMAN/*
+/data/external/structures/AlphaFoldDB/*
 
 # exclude results from source control
 /results/*
+/results_archive/*
 
 # exclude KinMap PNG files
 /notebooks/evaluation/results/kinmap/*png

--- a/notebooks/comparison/subset_fingerprints.ipynb
+++ b/notebooks/comparison/subset_fingerprints.ipynb
@@ -1,0 +1,762 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "089c4108-2acb-4ad6-b4ac-b4221fbfa7cc",
+   "metadata": {},
+   "source": [
+    "# Subsetting fingerprints"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f7a29306-1062-4b58-bdfd-616b5aa6dc65",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f598cc60f914405fa14b99e550a3b6d2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from kissim.encoding import FingerprintGenerator\n",
+    "from kissim.comparison import FingerprintDistanceGenerator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec3de6c2-9c8d-4144-b4a8-b85c2d624db8",
+   "metadata": {},
+   "source": [
+    "## `kissim` pipeline with full fingerprints"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f1a40a80-8ed7-47b0-8bd6-3eadd5966fcd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fps = FingerprintGenerator.from_structure_klifs_ids([12347, 3825])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e07d81c8-06ac-42d9-b6d4-01343b1ce715",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d536a146bd654b2694e3b5322d3abc0f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculate pairwise fingerprint distance:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8e065b3e147d457a8c9775893e904a11",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculate pairwise fingerprint coverage:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "d = FingerprintDistanceGenerator.from_fingerprint_generator(fps)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0e46de43-cbe1-4554-92bd-51240d5acf3e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>structure.1</th>\n",
+       "      <th>structure.2</th>\n",
+       "      <th>kinase.1</th>\n",
+       "      <th>kinase.2</th>\n",
+       "      <th>distance</th>\n",
+       "      <th>bit_coverage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>12347</td>\n",
+       "      <td>3825</td>\n",
+       "      <td>BRAF</td>\n",
+       "      <td>CASK</td>\n",
+       "      <td>0.272455</td>\n",
+       "      <td>0.92</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   structure.1  structure.2 kinase.1 kinase.2  distance  bit_coverage\n",
+       "0        12347         3825     BRAF     CASK  0.272455          0.92"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81ae2b35-5abb-4cf0-ba7d-64308c80ef42",
+   "metadata": {},
+   "source": [
+    "## `kissim` pipeline with subset fingerprints"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84a547fb-174c-4a93-ac50-4e90f8ad0b65",
+   "metadata": {},
+   "source": [
+    "### Define subset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0b5f3450-c956-4f50-88e1-63569dcef84f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "selected_residue_ixs = [10, 30, 70]\n",
+    "selected_residue_ixs = [i - 1 for i in selected_residue_ixs]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f0c447d5-a918-49ea-8b35-dc0994ebdf38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def subset_fingerprint_generator(structure_klifs_ids):\n",
+    "    \n",
+    "    fps_subset = FingerprintGenerator.from_structure_klifs_ids(structure_klifs_ids)\n",
+    "\n",
+    "    for id_, fp in fps_subset.data.items():\n",
+    "        fp_dict = {}\n",
+    "        for feature_name1, features1 in fp.values_dict.items():\n",
+    "            fp_dict[feature_name1] = {}\n",
+    "            if feature_name1 == \"physicochemical\":\n",
+    "                for feature_name2, features2 in features1.items():\n",
+    "                    fp_dict[feature_name1][feature_name2] = np.array(features2)[selected_residue_ixs].tolist()\n",
+    "            else:\n",
+    "                for feature_name2, features2 in features1.items():\n",
+    "                    fp_dict[feature_name1][feature_name2] = {}\n",
+    "                    if feature_name2 == \"distances\":\n",
+    "                        for feature_name3, features3 in features2.items():\n",
+    "                            fp_dict[feature_name1][feature_name2][feature_name3] = np.array(features3)[selected_residue_ixs].tolist()\n",
+    "                    else:\n",
+    "                        fp_dict[feature_name1][feature_name2] = {}\n",
+    "                        for feature_name3, features3 in features2.items():\n",
+    "                            fp_dict[feature_name1][feature_name2][feature_name3] = np.array(features3)\n",
+    "\n",
+    "        fp.values_dict = fp_dict\n",
+    "        fp.residue_ids = np.array(fp.residue_ids)[selected_residue_ixs].tolist()\n",
+    "        fp.residue_ixs = np.array(fp.residue_ixs)[selected_residue_ixs].tolist()\n",
+    "        \n",
+    "        fps_subset.data[id_] = fp\n",
+    "\n",
+    "    return fps_subset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ff552314-ca43-4ed7-87cf-a46d0d9e45fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "structure_klifs_ids = [12347, 3825]\n",
+    "fps_subset = subset_fingerprint_generator(structure_klifs_ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "51285aaf-0264-4bba-853a-1747e5b5ee19",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "96c8b32a44a64f1da5f935b7491a8b57",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculate pairwise fingerprint distance:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a95708443d964e249da19fde2258d95d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculate pairwise fingerprint coverage:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "d_subset = FingerprintDistanceGenerator.from_fingerprint_generator(fps_subset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "58cd91e4-9953-4b55-a8f3-713729a4f133",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>structure.1</th>\n",
+       "      <th>structure.2</th>\n",
+       "      <th>kinase.1</th>\n",
+       "      <th>kinase.2</th>\n",
+       "      <th>distance</th>\n",
+       "      <th>bit_coverage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>12347</td>\n",
+       "      <td>3825</td>\n",
+       "      <td>BRAF</td>\n",
+       "      <td>CASK</td>\n",
+       "      <td>0.325399</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   structure.1  structure.2 kinase.1 kinase.2  distance  bit_coverage\n",
+       "0        12347         3825     BRAF     CASK  0.325399           1.0"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d_subset.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "425cf3a7-c8aa-4e25-a8af-c6d9d22ed12c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "0b4935e4d73f4b78b05394d5245aa01c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "29595e5afc834949a520771b3e187c33": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2d8d48392e234298b66b97827fa3963f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d07cb9be797b4ad2b2637e6420a9181d",
+       "style": "IPY_MODEL_dc8d22350f71418b93e26edbe8c4a6d6",
+       "value": "Calculate pairwise fingerprint coverage: 100%"
+      }
+     },
+     "3b54da5fd755454aa3c5004731e924dd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_6d7d800494a64c6ea37b314c723fd4d9",
+       "max": 1,
+       "style": "IPY_MODEL_edab4c2f402a4ba08cc1406035db2ecf",
+       "value": 1
+      }
+     },
+     "41cb82c0e7fd4179a77ecd540173d4e3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_d297e81082fb4b968b6dae4e3e7a9c38",
+       "max": 1,
+       "style": "IPY_MODEL_29595e5afc834949a520771b3e187c33",
+       "value": 1
+      }
+     },
+     "42bc134e38214249b165a32eb08ddfdc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "44cb140c66a6419c97e214643d223e69": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "45ff8f5e11b2442bbab032fdb7125904": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_671ea5393c654113a8e0777092f26323",
+       "style": "IPY_MODEL_64beb355f1a744e090169011353b8a04",
+       "value": " 1/1 [00:00&lt;00:00, 65.98it/s]"
+      }
+     },
+     "5c90fe773df343a5ad29d47d869eb914": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5d3ec6bee0a74992b67f185d6ebf09ae": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "60344b1e4db74f39a02ed62213c84124": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "64beb355f1a744e090169011353b8a04": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "671ea5393c654113a8e0777092f26323": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "68fabab2ac2f45aca4725b4266ef4931": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5d3ec6bee0a74992b67f185d6ebf09ae",
+       "style": "IPY_MODEL_60344b1e4db74f39a02ed62213c84124",
+       "value": "Calculate pairwise fingerprint distance: 100%"
+      }
+     },
+     "69bb23af111149efbcede0b0950f3bd7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6d7d800494a64c6ea37b314c723fd4d9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6e123c4594184a1f852a24c5726967bd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6ed8898f3f2c48d1ab6bb96d1f0d94ca": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "80e7155c72144faf8c1204d9fc589e1f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "81756ec6be2d4275811b63d01ee161b9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "89f7eaf491b9462e8f008a1c3aac4fa9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8e065b3e147d457a8c9775893e904a11": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c36e17199e6a45e0b9a1ffcd3f3702cd",
+        "IPY_MODEL_41cb82c0e7fd4179a77ecd540173d4e3",
+        "IPY_MODEL_45ff8f5e11b2442bbab032fdb7125904"
+       ],
+       "layout": "IPY_MODEL_e20f3be6325f4222a7c48ed3b49bae06"
+      }
+     },
+     "96c8b32a44a64f1da5f935b7491a8b57": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_68fabab2ac2f45aca4725b4266ef4931",
+        "IPY_MODEL_edd481c84b9b4a379f08e2f1b0e4492e",
+        "IPY_MODEL_fe76ff2946a14e9590fcfd6df8c005bb"
+       ],
+       "layout": "IPY_MODEL_ec563ed681d6433285996b74705f0f13"
+      }
+     },
+     "a95708443d964e249da19fde2258d95d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_2d8d48392e234298b66b97827fa3963f",
+        "IPY_MODEL_3b54da5fd755454aa3c5004731e924dd",
+        "IPY_MODEL_c2495aed7eb54b5daf10e5255ad6fdf1"
+       ],
+       "layout": "IPY_MODEL_42bc134e38214249b165a32eb08ddfdc"
+      }
+     },
+     "ac267f2e5cab49029cba2b50f4c5fa16": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b575f2491d5a410c98eb71a992e67361": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c2495aed7eb54b5daf10e5255ad6fdf1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6e123c4594184a1f852a24c5726967bd",
+       "style": "IPY_MODEL_44cb140c66a6419c97e214643d223e69",
+       "value": " 1/1 [00:00&lt;00:00, 64.58it/s]"
+      }
+     },
+     "c312d8abb3f54cab9e3982619b22080c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_ac267f2e5cab49029cba2b50f4c5fa16",
+       "max": 1,
+       "style": "IPY_MODEL_eb2eeb4339c7434eac210e2092b66ca1",
+       "value": 1
+      }
+     },
+     "c36e17199e6a45e0b9a1ffcd3f3702cd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5c90fe773df343a5ad29d47d869eb914",
+       "style": "IPY_MODEL_89f7eaf491b9462e8f008a1c3aac4fa9",
+       "value": "Calculate pairwise fingerprint coverage: 100%"
+      }
+     },
+     "c5e3ddd86c514bc8a3d4240ca4c4564f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c6d49a461c9449768d5bbc77ebfa92ca": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cea9defa711a4210a51f1ec9b5613c6c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_81756ec6be2d4275811b63d01ee161b9",
+       "style": "IPY_MODEL_b575f2491d5a410c98eb71a992e67361",
+       "value": "Calculate pairwise fingerprint distance: 100%"
+      }
+     },
+     "d07cb9be797b4ad2b2637e6420a9181d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d297e81082fb4b968b6dae4e3e7a9c38": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d536a146bd654b2694e3b5322d3abc0f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_cea9defa711a4210a51f1ec9b5613c6c",
+        "IPY_MODEL_c312d8abb3f54cab9e3982619b22080c",
+        "IPY_MODEL_e5eebd590bff45439528954ff05bde6e"
+       ],
+       "layout": "IPY_MODEL_f09a6a5f53b442f888d2aab946d2e14c"
+      }
+     },
+     "dc8d22350f71418b93e26edbe8c4a6d6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e20f3be6325f4222a7c48ed3b49bae06": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e5eebd590bff45439528954ff05bde6e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6ed8898f3f2c48d1ab6bb96d1f0d94ca",
+       "style": "IPY_MODEL_c6d49a461c9449768d5bbc77ebfa92ca",
+       "value": " 1/1 [00:00&lt;00:00, 62.22it/s]"
+      }
+     },
+     "eb2eeb4339c7434eac210e2092b66ca1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ec563ed681d6433285996b74705f0f13": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "edab4c2f402a4ba08cc1406035db2ecf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "edd481c84b9b4a379f08e2f1b0e4492e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_0b4935e4d73f4b78b05394d5245aa01c",
+       "max": 1,
+       "style": "IPY_MODEL_80e7155c72144faf8c1204d9fc589e1f",
+       "value": 1
+      }
+     },
+     "f09a6a5f53b442f888d2aab946d2e14c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f2b90b2f1f3245c8bf28fa0c4b6c7799": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f598cc60f914405fa14b99e550a3b6d2": {
+      "model_module": "nglview-js-widgets",
+      "model_module_version": "3.0.1",
+      "model_name": "ColormakerRegistryModel",
+      "state": {
+       "_msg_ar": [],
+       "_msg_q": [],
+       "_ready": true,
+       "layout": "IPY_MODEL_69bb23af111149efbcede0b0950f3bd7"
+      }
+     },
+     "fe76ff2946a14e9590fcfd6df8c005bb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f2b90b2f1f3245c8bf28fa0c4b6c7799",
+       "style": "IPY_MODEL_c5e3ddd86c514bc8a3d4240ca4c4564f",
+       "value": " 1/1 [00:00&lt;00:00, 61.72it/s]"
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/comparison/subset_fingerprints.ipynb
+++ b/notebooks/comparison/subset_fingerprints.ipynb
@@ -17,7 +17,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f598cc60f914405fa14b99e550a3b6d2",
+       "model_id": "8d480e5bafad4e6f9af3c97fe55dd6ad",
        "version_major": 2,
        "version_minor": 0
       },
@@ -28,6 +28,8 @@
     }
    ],
    "source": [
+    "from pathlib import Path\n",
+    "\n",
     "import numpy as np\n",
     "\n",
     "from kissim.encoding import FingerprintGenerator\n",
@@ -35,114 +37,48 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "ec3de6c2-9c8d-4144-b4a8-b85c2d624db8",
-   "metadata": {},
-   "source": [
-    "## `kissim` pipeline with full fingerprints"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f1a40a80-8ed7-47b0-8bd6-3eadd5966fcd",
+   "id": "4ad7009b-3eae-42c0-ac34-5ea00514cc59",
    "metadata": {},
    "outputs": [],
    "source": [
-    "fps = FingerprintGenerator.from_structure_klifs_ids([12347, 3825])"
+    "HERE = Path(_dh[-1])  # noqa: F821\n",
+    "RESULTS = HERE / \"../../results/dfg_out\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4770bda-e201-4e87-91a2-e1ac1d263528",
+   "metadata": {},
+   "source": [
+    "## Residue subsets"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "e07d81c8-06ac-42d9-b6d4-01343b1ce715",
+   "id": "531b1c41-4757-41b4-9b84-a9af0c65c15b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d536a146bd654b2694e3b5322d3abc0f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Calculate pairwise fingerprint distance:   0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8e065b3e147d457a8c9775893e904a11",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Calculate pairwise fingerprint coverage:   0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "d = FingerprintDistanceGenerator.from_fingerprint_generator(fps)"
+    "selected_residue_ixs = {\n",
+    "    \"dfg_all\": [1,2,3,4,5,6,7,8,9,10,11,12,13,15,16,17,19,20,21,23,24,25,27,28,31,35,36,37,38,41,43,44,45,46,47,48,49,50,51,52,53,54,55,56,59,60,61,64,66,67,68,69,70,72,74,75,76,77,79,80,81,82,83,84,85],\n",
+    "    \"dfg_in\": [1,2,3,4,5,6,7,8,9,10,11,12,13,15,16,17,19,20,21,24,25,27,28,36,37,38,43,44,45,46,47,48,49,50,51,52,54,55,59,70,72,74,75,76,77,80,81,82,83,84,85],\n",
+    "    \"dfg_out\": [3,4,5,6,7,8,9,11,12,13,15,16,17,19,20,21,23,24,25,27,28,31,35,36,37,38,43,44,45,46,47,48,49,50,51,52,54,55,60,61,64,66,67,68,69,70,74,75,77,79,80,81,82,83,84,85],\n",
+    "}"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "0e46de43-cbe1-4554-92bd-51240d5acf3e",
+   "id": "8482ad8c-563e-4d79-9745-086031e8c5b8",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>structure.1</th>\n",
-       "      <th>structure.2</th>\n",
-       "      <th>kinase.1</th>\n",
-       "      <th>kinase.2</th>\n",
-       "      <th>distance</th>\n",
-       "      <th>bit_coverage</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>12347</td>\n",
-       "      <td>3825</td>\n",
-       "      <td>BRAF</td>\n",
-       "      <td>CASK</td>\n",
-       "      <td>0.272455</td>\n",
-       "      <td>0.92</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
       "text/plain": [
-       "   structure.1  structure.2 kinase.1 kinase.2  distance  bit_coverage\n",
-       "0        12347         3825     BRAF     CASK  0.272455          0.92"
+       "{'dfg_all': 65, 'dfg_in': 51, 'dfg_out': 56}"
       ]
      },
      "execution_count": 4,
@@ -151,7 +87,36 @@
     }
    ],
    "source": [
-    "d.data"
+    "{k: len(v) for k, v in selected_residue_ixs.items()}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ed0e0ca-94db-487f-bcd4-0cb31180daf8",
+   "metadata": {},
+   "source": [
+    "## Load fingerprints"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f1a40a80-8ed7-47b0-8bd6-3eadd5966fcd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "484\n",
+      "{1032}\n"
+     ]
+    }
+   ],
+   "source": [
+    "fingerprints = FingerprintGenerator.from_json(RESULTS / \"fingerprints.json\")\n",
+    "print(len(fingerprints.data))\n",
+    "print(set([len(v.values_array()) for k, v in fingerprints.data.items()]))"
    ]
   },
   {
@@ -163,36 +128,17 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "84a547fb-174c-4a93-ac50-4e90f8ad0b65",
-   "metadata": {},
-   "source": [
-    "### Define subset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "0b5f3450-c956-4f50-88e1-63569dcef84f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "selected_residue_ixs = [10, 30, 70]\n",
-    "selected_residue_ixs = [i - 1 for i in selected_residue_ixs]"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "f0c447d5-a918-49ea-8b35-dc0994ebdf38",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def subset_fingerprint_generator(structure_klifs_ids):\n",
+    "def subset_fingerprint_generator(fingerprints, selected_residue_ixs):\n",
     "    \n",
-    "    fps_subset = FingerprintGenerator.from_structure_klifs_ids(structure_klifs_ids)\n",
+    "    selected_residue_ixs = [i - 1 for i in selected_residue_ixs]\n",
     "\n",
-    "    for id_, fp in fps_subset.data.items():\n",
+    "    for id_, fp in fingerprints.data.items():\n",
     "        fp_dict = {}\n",
     "        for feature_name1, features1 in fp.values_dict.items():\n",
     "            fp_dict[feature_name1] = {}\n",
@@ -214,9 +160,9 @@
     "        fp.residue_ids = np.array(fp.residue_ids)[selected_residue_ixs].tolist()\n",
     "        fp.residue_ixs = np.array(fp.residue_ixs)[selected_residue_ixs].tolist()\n",
     "        \n",
-    "        fps_subset.data[id_] = fp\n",
+    "        fingerprints.data[id_] = fp\n",
     "\n",
-    "    return fps_subset"
+    "    return fingerprints"
    ]
   },
   {
@@ -224,111 +170,29 @@
    "execution_count": 7,
    "id": "ff552314-ca43-4ed7-87cf-a46d0d9e45fe",
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "structure_klifs_ids = [12347, 3825]\n",
-    "fps_subset = subset_fingerprint_generator(structure_klifs_ids)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "51285aaf-0264-4bba-853a-1747e5b5ee19",
-   "metadata": {},
    "outputs": [
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "96c8b32a44a64f1da5f935b7491a8b57",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Calculate pairwise fingerprint distance:   0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a95708443d964e249da19fde2258d95d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Calculate pairwise fingerprint coverage:   0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "484\n",
+      "{624}\n"
+     ]
     }
    ],
    "source": [
-    "d_subset = FingerprintDistanceGenerator.from_fingerprint_generator(fps_subset)"
+    "fps_subset = subset_fingerprint_generator(fingerprints, selected_residue_ixs = selected_residue_ixs[\"dfg_in\"])\n",
+    "print(len(fps_subset.data))\n",
+    "print(set([len(v.values_array()) for k, v in fps_subset.data.items()]))"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "58cd91e4-9953-4b55-a8f3-713729a4f133",
+   "cell_type": "raw",
+   "id": "7c5f526e-334d-4f75-b56d-324a9705f063",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>structure.1</th>\n",
-       "      <th>structure.2</th>\n",
-       "      <th>kinase.1</th>\n",
-       "      <th>kinase.2</th>\n",
-       "      <th>distance</th>\n",
-       "      <th>bit_coverage</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>12347</td>\n",
-       "      <td>3825</td>\n",
-       "      <td>BRAF</td>\n",
-       "      <td>CASK</td>\n",
-       "      <td>0.325399</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   structure.1  structure.2 kinase.1 kinase.2  distance  bit_coverage\n",
-       "0        12347         3825     BRAF     CASK  0.325399           1.0"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
+    "%%time\n",
+    "d_subset = FingerprintDistanceGenerator.from_fingerprint_generator(fps_subset)\n",
     "d_subset.data"
    ]
   },
@@ -362,375 +226,7 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "0b4935e4d73f4b78b05394d5245aa01c": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "29595e5afc834949a520771b3e187c33": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "2d8d48392e234298b66b97827fa3963f": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_d07cb9be797b4ad2b2637e6420a9181d",
-       "style": "IPY_MODEL_dc8d22350f71418b93e26edbe8c4a6d6",
-       "value": "Calculate pairwise fingerprint coverage: 100%"
-      }
-     },
-     "3b54da5fd755454aa3c5004731e924dd": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "bar_style": "success",
-       "layout": "IPY_MODEL_6d7d800494a64c6ea37b314c723fd4d9",
-       "max": 1,
-       "style": "IPY_MODEL_edab4c2f402a4ba08cc1406035db2ecf",
-       "value": 1
-      }
-     },
-     "41cb82c0e7fd4179a77ecd540173d4e3": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "bar_style": "success",
-       "layout": "IPY_MODEL_d297e81082fb4b968b6dae4e3e7a9c38",
-       "max": 1,
-       "style": "IPY_MODEL_29595e5afc834949a520771b3e187c33",
-       "value": 1
-      }
-     },
-     "42bc134e38214249b165a32eb08ddfdc": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "44cb140c66a6419c97e214643d223e69": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "45ff8f5e11b2442bbab032fdb7125904": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_671ea5393c654113a8e0777092f26323",
-       "style": "IPY_MODEL_64beb355f1a744e090169011353b8a04",
-       "value": " 1/1 [00:00&lt;00:00, 65.98it/s]"
-      }
-     },
-     "5c90fe773df343a5ad29d47d869eb914": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "5d3ec6bee0a74992b67f185d6ebf09ae": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "60344b1e4db74f39a02ed62213c84124": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "64beb355f1a744e090169011353b8a04": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "671ea5393c654113a8e0777092f26323": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "68fabab2ac2f45aca4725b4266ef4931": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_5d3ec6bee0a74992b67f185d6ebf09ae",
-       "style": "IPY_MODEL_60344b1e4db74f39a02ed62213c84124",
-       "value": "Calculate pairwise fingerprint distance: 100%"
-      }
-     },
-     "69bb23af111149efbcede0b0950f3bd7": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "6d7d800494a64c6ea37b314c723fd4d9": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "6e123c4594184a1f852a24c5726967bd": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "6ed8898f3f2c48d1ab6bb96d1f0d94ca": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "80e7155c72144faf8c1204d9fc589e1f": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "81756ec6be2d4275811b63d01ee161b9": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "89f7eaf491b9462e8f008a1c3aac4fa9": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "8e065b3e147d457a8c9775893e904a11": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "children": [
-        "IPY_MODEL_c36e17199e6a45e0b9a1ffcd3f3702cd",
-        "IPY_MODEL_41cb82c0e7fd4179a77ecd540173d4e3",
-        "IPY_MODEL_45ff8f5e11b2442bbab032fdb7125904"
-       ],
-       "layout": "IPY_MODEL_e20f3be6325f4222a7c48ed3b49bae06"
-      }
-     },
-     "96c8b32a44a64f1da5f935b7491a8b57": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "children": [
-        "IPY_MODEL_68fabab2ac2f45aca4725b4266ef4931",
-        "IPY_MODEL_edd481c84b9b4a379f08e2f1b0e4492e",
-        "IPY_MODEL_fe76ff2946a14e9590fcfd6df8c005bb"
-       ],
-       "layout": "IPY_MODEL_ec563ed681d6433285996b74705f0f13"
-      }
-     },
-     "a95708443d964e249da19fde2258d95d": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "children": [
-        "IPY_MODEL_2d8d48392e234298b66b97827fa3963f",
-        "IPY_MODEL_3b54da5fd755454aa3c5004731e924dd",
-        "IPY_MODEL_c2495aed7eb54b5daf10e5255ad6fdf1"
-       ],
-       "layout": "IPY_MODEL_42bc134e38214249b165a32eb08ddfdc"
-      }
-     },
-     "ac267f2e5cab49029cba2b50f4c5fa16": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "b575f2491d5a410c98eb71a992e67361": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "c2495aed7eb54b5daf10e5255ad6fdf1": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_6e123c4594184a1f852a24c5726967bd",
-       "style": "IPY_MODEL_44cb140c66a6419c97e214643d223e69",
-       "value": " 1/1 [00:00&lt;00:00, 64.58it/s]"
-      }
-     },
-     "c312d8abb3f54cab9e3982619b22080c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "bar_style": "success",
-       "layout": "IPY_MODEL_ac267f2e5cab49029cba2b50f4c5fa16",
-       "max": 1,
-       "style": "IPY_MODEL_eb2eeb4339c7434eac210e2092b66ca1",
-       "value": 1
-      }
-     },
-     "c36e17199e6a45e0b9a1ffcd3f3702cd": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_5c90fe773df343a5ad29d47d869eb914",
-       "style": "IPY_MODEL_89f7eaf491b9462e8f008a1c3aac4fa9",
-       "value": "Calculate pairwise fingerprint coverage: 100%"
-      }
-     },
-     "c5e3ddd86c514bc8a3d4240ca4c4564f": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "c6d49a461c9449768d5bbc77ebfa92ca": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "cea9defa711a4210a51f1ec9b5613c6c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_81756ec6be2d4275811b63d01ee161b9",
-       "style": "IPY_MODEL_b575f2491d5a410c98eb71a992e67361",
-       "value": "Calculate pairwise fingerprint distance: 100%"
-      }
-     },
-     "d07cb9be797b4ad2b2637e6420a9181d": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "d297e81082fb4b968b6dae4e3e7a9c38": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "d536a146bd654b2694e3b5322d3abc0f": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "children": [
-        "IPY_MODEL_cea9defa711a4210a51f1ec9b5613c6c",
-        "IPY_MODEL_c312d8abb3f54cab9e3982619b22080c",
-        "IPY_MODEL_e5eebd590bff45439528954ff05bde6e"
-       ],
-       "layout": "IPY_MODEL_f09a6a5f53b442f888d2aab946d2e14c"
-      }
-     },
-     "dc8d22350f71418b93e26edbe8c4a6d6": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "e20f3be6325f4222a7c48ed3b49bae06": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "e5eebd590bff45439528954ff05bde6e": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_6ed8898f3f2c48d1ab6bb96d1f0d94ca",
-       "style": "IPY_MODEL_c6d49a461c9449768d5bbc77ebfa92ca",
-       "value": " 1/1 [00:00&lt;00:00, 62.22it/s]"
-      }
-     },
-     "eb2eeb4339c7434eac210e2092b66ca1": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "ec563ed681d6433285996b74705f0f13": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "edab4c2f402a4ba08cc1406035db2ecf": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "edd481c84b9b4a379f08e2f1b0e4492e": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "bar_style": "success",
-       "layout": "IPY_MODEL_0b4935e4d73f4b78b05394d5245aa01c",
-       "max": 1,
-       "style": "IPY_MODEL_80e7155c72144faf8c1204d9fc589e1f",
-       "value": 1
-      }
-     },
-     "f09a6a5f53b442f888d2aab946d2e14c": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "f2b90b2f1f3245c8bf28fa0c4b6c7799": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "f598cc60f914405fa14b99e550a3b6d2": {
+     "8d480e5bafad4e6f9af3c97fe55dd6ad": {
       "model_module": "nglview-js-widgets",
       "model_module_version": "3.0.1",
       "model_name": "ColormakerRegistryModel",
@@ -738,18 +234,14 @@
        "_msg_ar": [],
        "_msg_q": [],
        "_ready": true,
-       "layout": "IPY_MODEL_69bb23af111149efbcede0b0950f3bd7"
+       "layout": "IPY_MODEL_dc2d7ae96ff74e548a6bbb135467722e"
       }
      },
-     "fe76ff2946a14e9590fcfd6df8c005bb": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_f2b90b2f1f3245c8bf28fa0c4b6c7799",
-       "style": "IPY_MODEL_c5e3ddd86c514bc8a3d4240ca4c4564f",
-       "value": " 1/1 [00:00&lt;00:00, 61.72it/s]"
-      }
+     "dc2d7ae96ff74e548a6bbb135467722e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
      }
     },
     "version_major": 2,


### PR DESCRIPTION
## Description

Some pocket residues are more important than others for ligand binding. Use only fingerprint bits describing important ligand-interacting residues (fingerprint subset).

List of ligand-contacting residues deposited in this issue:
https://github.com/volkamerlab/kissim/issues/77

## Todos
  - [x] Add test notebook showing how this feature could be quickly implemented inside the existing `kissim` code
  - [x] Run test code on small kinase dataset and compare to full fingerprint

## Questions
None.

## Status
This is only a draft - the subsetting is implemented in `kissim` in PR https://github.com/volkamerlab/kissim/pull/80